### PR TITLE
CASMHMS-5446 Add initial set of PCS CT tests and runCT environment

### DIFF
--- a/changelog/v0.2.md
+++ b/changelog/v0.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v0.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2022-03-31
+## [0.2.0] - 2022-04-05
 
 ### Added
 - Added PCS CT smoke and functional tests.

--- a/changelog/v0.2.md
+++ b/changelog/v0.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v0.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2022-03-24
+## [0.2.0] - 2022-03-31
 
 ### Added
 - Added PCS CT smoke and functional tests.

--- a/changelog/v0.2.md
+++ b/changelog/v0.2.md
@@ -1,0 +1,26 @@
+# Changelog for v0.2
+
+All notable changes to this project for v0.2.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2022-03-24
+
+### Added
+- Added PCS CT smoke and functional tests.
+- Added a runCT.sh script that can run the CT tests in a docker-compose environment.
+
+## [0.1.1] - 2022-03-17
+
+### Added
+- Updated PCS to contain recent changes (power monitoring, power capping, health).
+- Added liveness/readiness checks to chart.
+
+## [0.1.0] - 2022-02-01
+
+### Added
+- Add pod anti affinity to prevent the cray-power-control pods from existing on the same node.
+
+### Changed
+- Changed to use 3 replicas instead of 1.

--- a/charts/v0.2/cray-power-control/Chart.yaml
+++ b/charts/v0.2/cray-power-control/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: "cray-power-control"
+version: 0.2.0
+description: "Kubernetes resources for cray-power-control"
+home: "https://github.com/Cray-HPE/hms-power-control-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-power-control"
+dependencies:
+  - name: cray-service
+    version: "~7.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: 0.0.6-20220324174358.48ded48
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v0.2/cray-power-control/Chart.yaml
+++ b/charts/v0.2/cray-power-control/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 0.0.6-20220331212029.2cb1de3
+appVersion: 0.0.6-20220405201636.f7678eb
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v0.2/cray-power-control/Chart.yaml
+++ b/charts/v0.2/cray-power-control/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 0.0.6-20220324174358.48ded48
+appVersion: 0.0.6-20220331212029.2cb1de3
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v0.2/cray-power-control/templates/configmaps.yaml
+++ b/charts/v0.2/cray-power-control/templates/configmaps.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-power-control-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"

--- a/charts/v0.2/cray-power-control/templates/tests/test-functional.yaml
+++ b/charts/v0.2/cray-power-control/templates/tests/test-functional.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]

--- a/charts/v0.2/cray-power-control/templates/tests/test-smoke.yaml
+++ b/charts/v0.2/cray-power-control/templates/tests/test-smoke.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]

--- a/charts/v0.2/cray-power-control/values.yaml
+++ b/charts/v0.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 0.0.6-20220331212029.2cb1de3
-  testVersion: 0.0.6-20220331212030.2cb1de3
+  appVersion: 0.0.6-20220405201636.f7678eb
+  testVersion: 0.0.6-20220405202245.f7678eb
 
 tests:
   image:

--- a/charts/v0.2/cray-power-control/values.yaml
+++ b/charts/v0.2/cray-power-control/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
   appVersion: 0.0.6-20220331212029.2cb1de3
-  testVersion: 0.0.6-20220331212029.2cb1de3
+  testVersion: 0.0.6-20220331212030.2cb1de3
 
 tests:
   image:

--- a/charts/v0.2/cray-power-control/values.yaml
+++ b/charts/v0.2/cray-power-control/values.yaml
@@ -1,0 +1,104 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+global:
+  appVersion: 0.0.6-20220324174358.48ded48
+  testVersion: 0.0.6-20220324174358.48ded48
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/unstable/cray-power-control-test
+    pullPolicy: IfNotPresent
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  etcdCluster:
+    enabled: true
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-power-control
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-power-control:
+      name: "cray-power-control"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/unstable/cray-power-control"
+      resources:
+        limits:
+          cpu: "4"
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      ports:
+        - name: http
+          containerPort: 28007
+      env:
+        - name: LOG_LEVEL
+          value: "DEBUG"
+        - name: SMS_SERVER
+          value: "http://cray-smd"
+        - name: VAULT_ENABLED
+          value: "true"
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: TRS_IMPLEMENTATION
+          value: "LOCAL"
+        - name: SERVICE_RESERVATION_VERBOSITY
+          value: "ERROR"
+        - name: HSMLOCK_ENABLED
+          value: "true"
+        - name: STORAGE
+          value: "ETCD"
+        - name: PCS_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: cray-power-control-cacert-info
+              key: CA_URI
+      livenessProbe:
+        httpGet:
+          port: 28007
+          path: /liveness
+        initialDelaySeconds: 15
+        periodSeconds: 5
+      readinessProbe:
+        httpGet:
+          port: 28007
+          path: /readiness
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 25
+      volumeMounts:
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+  ingress:
+    enabled: true
+    uri: "/"
+    prefix: "/apis/power-control/v1/"

--- a/charts/v0.2/cray-power-control/values.yaml
+++ b/charts/v0.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 0.0.6-20220324174358.48ded48
-  testVersion: 0.0.6-20220324174358.48ded48
+  appVersion: 0.0.6-20220331212029.2cb1de3
+  testVersion: 0.0.6-20220331212029.2cb1de3
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -13,7 +13,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "0.0.1": "0.0.1-20220201202912.1ad88cd"
   "0.1.1": "0.0.5-20220317122020.1b19afe"
-  "0.2.0": "0.0.6-20220324174358.48ded48"
+  "0.2.0": "0.0.6-20220331212029.2cb1de3"
 
 
 # Test results for combinations of Chart, Application, and CSM versions.

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -4,6 +4,7 @@ chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=0.0.1": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=0.1.0": "~1.3.0"
+  ">=0.2.0": "~1.3.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -12,6 +13,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "0.0.1": "0.0.1-20220201202912.1ad88cd"
   "0.1.1": "0.0.5-20220317122020.1b19afe"
+  "0.2.0": "0.0.6-20220324174358.48ded48"
 
 
 # Test results for combinations of Chart, Application, and CSM versions.

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -13,7 +13,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "0.0.1": "0.0.1-20220201202912.1ad88cd"
   "0.1.1": "0.0.5-20220317122020.1b19afe"
-  "0.2.0": "0.0.6-20220331212029.2cb1de3"
+  "0.2.0": "0.0.6-20220405201636.f7678eb"
 
 
 # Test results for combinations of Chart, Application, and CSM versions.


### PR DESCRIPTION
### Summary and Scope

This change adds an initial set of non-disruptive CT smoke and functional tests for PCS. It also adds infrastructure needed to spin up an instance of PCS (along with all of its dependencies) and execute the CT tests against it in a runCT environment as part of a GitHub workflow. Lastly, it adds smoke and functional test jobs to the PCS Helm chart so the CT tests can be executed on a live system.

### Issues and Related PRs

* Resolves CASMHMS-5446.

### Testing

This change was tested by running the PCS unit, integration, and CT tests locally as well as within GitHub workflows. It was also tested by deploying PCS on Mug, executing the CT smoke and functional Helm test jobs, and verifying that they all passed.

Was a fresh Install tested? Y
Was an Upgrade tested? N, PCS not installed on CSM-1.2 systems.
Was a Downgrade tested? N, PCS not installed on CSM-1.2 systems.

### Risks and Mitigations

Low risk.