### PR TITLE
Improve PCS transitions to reacquire component reservations after restart

### DIFF
--- a/changelog/v1.1.md
+++ b/changelog/v1.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v1.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-01-31
+
+### Changed
+
+- CASMHMS-5863 - Updated the PCS image version to 1.2.0
+
 ## [1.1.0] - 2023-01-23
 
 ### Added

--- a/changelog/v1.1.md
+++ b/changelog/v1.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CASMHMS-5863 - Updated the PCS image version to 1.2.0
+- CASMHMS-5863 - Updated the PCS image version to 1.3.0
 
 ## [1.1.0] - 2023-01-23
 

--- a/charts/v1.1/cray-power-control/Chart.yaml
+++ b/charts/v1.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.1.0
+version: 1.1.1
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.0.0
+appVersion: 1.2.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.1/cray-power-control/Chart.yaml
+++ b/charts/v1.1/cray-power-control/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.2.0
+appVersion: 1.3.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.1/cray-power-control/values.yaml
+++ b/charts/v1.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.0.0
-  testVersion: 1.0.0
+  appVersion: 1.2.0
+  testVersion: 1.2.0
 
 tests:
   image:

--- a/charts/v1.1/cray-power-control/values.yaml
+++ b/charts/v1.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.2.0
-  testVersion: 1.2.0
+  appVersion: 1.3.0
+  testVersion: 1.3.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -5,7 +5,7 @@ chartVersionToCSMVersion:
   ">=0.0.1": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=0.1.0": "~1.3.0"
   ">=0.2.0": "~1.3.0"
-  ">=1.0.0": "~1.6.0"
+  ">=1.0.0": "~1.4.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -18,6 +18,7 @@ chartVersionToApplicationVersion:
   "1.0.0": "1.0.0"
   "1.0.1": "1.0.0"
   "1.1.0": "1.0.0"
+  "1.1.1": "1.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -18,7 +18,7 @@ chartVersionToApplicationVersion:
   "1.0.0": "1.0.0"
   "1.0.1": "1.0.0"
   "1.1.0": "1.0.0"
-  "1.1.1": "1.2.0"
+  "1.1.1": "1.3.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Improve PCS transitions to reacquire component reservations after restart

## Issues and Related PRs

* Resolves [CASMHMS-5863](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5863)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/25

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable