### PR TITLE
CASMINST-5879 PCS CT test updates for production systems

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Cray / HPE
+Copyright (c) 2022-2023 Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog/v1.0.md
+++ b/changelog/v1.0.md
@@ -5,6 +5,11 @@ All notable changes to this project for v1.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2023-02-01
+
+### Changed
+- Updates to non-disruptive CT tests for production systems
+
 ## [1.0.1] - 2023-01-23
 
 ### Added

--- a/changelog/v1.1.md
+++ b/changelog/v1.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v1.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-02-01
+
+### Changed
+- Updates to non-disruptive CT tests for production systems
+
 ## [1.1.0] - 2023-01-23
 
 ### Added

--- a/charts/v1.0/cray-power-control/Chart.yaml
+++ b/charts/v1.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.0.1
+version: 1.0.2
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.0.0
+appVersion: 1.2.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.0/cray-power-control/templates/tests/test-functional.yaml
+++ b/charts/v1.0/cray-power-control/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v1.0/cray-power-control/templates/tests/test-smoke.yaml
+++ b/charts/v1.0/cray-power-control/templates/tests/test-smoke.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]

--- a/charts/v1.0/cray-power-control/values.yaml
+++ b/charts/v1.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.0.0
-  testVersion: 1.0.0
+  appVersion: 1.2.0
+  testVersion: 1.2.0
 
 tests:
   image:

--- a/charts/v1.1/cray-power-control/Chart.yaml
+++ b/charts/v1.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.1.0
+version: 1.1.1
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.0.0
+appVersion: 1.2.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.1/cray-power-control/templates/tests/test-functional.yaml
+++ b/charts/v1.1/cray-power-control/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v1.1/cray-power-control/templates/tests/test-smoke.yaml
+++ b/charts/v1.1/cray-power-control/templates/tests/test-smoke.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]

--- a/charts/v1.1/cray-power-control/values.yaml
+++ b/charts/v1.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.0.0
-  testVersion: 1.0.0
+  appVersion: 1.2.0
+  testVersion: 1.2.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -5,7 +5,7 @@ chartVersionToCSMVersion:
   ">=0.0.1": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=0.1.0": "~1.3.0"
   ">=0.2.0": "~1.3.0"
-  ">=1.0.0": "~1.6.0"
+  ">=1.0.0": "~1.4.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "0.2.0": "0.0.6-20220405201636.f7678eb"
   "1.0.0": "1.0.0"
   "1.0.1": "1.0.0"
+  "1.0.2": "1.2.0"
   "1.1.0": "1.0.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -19,6 +19,7 @@ chartVersionToApplicationVersion:
   "1.0.1": "1.0.0"
   "1.0.2": "1.2.0"
   "1.1.0": "1.0.0"
+  "1.1.1": "1.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

This change updates the non-disruptive PCS CT tests for issues encountered in production environments vs. the runCT simulated environments in the build pipeline. The power-status test now avoids running against the CAN node since it has no ComponentEndpoint which is required to retrieve power-status. It also moves the power-status test cases for Chassis and ChassisBMC to the build pipeline bucket since these components aren't always guaranteed to be present in HSM in production environments.

### Issues and Related PRs

* Resolves CASMINST-5879.

### Testing

This change was tested by running the updated tests in the build pipeline, verifying that they passed, and that the Chassis and ChassisBMC power-status tests executed in the new test stage.

### Risks and Mitigations

Low risk.