### PR TITLE
PCS chart update for CASMHMS-5887

### DIFF
--- a/changelog/v1.0.md
+++ b/changelog/v1.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v1.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2023-02-06
+
+### Fixed
+- CASMHMS-5887 - power-status now shows 'unavailable' instead of 'undefined'.
+- CASMHMS-5863 - Improved transition restarts.
+
 ## [1.0.2] - 2023-02-01
 
 ### Changed

--- a/changelog/v1.1.md
+++ b/changelog/v1.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v1.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2023-02-06
+
+### Fixed
+- CASMHMS-5887 - power-status now shows 'unavailable' instead of 'undefined'.
+
 ## [1.1.2] - 2023-02-01
 
 ### Changed

--- a/charts/v1.0/cray-power-control/Chart.yaml
+++ b/charts/v1.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.0.2
+version: 1.0.3
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.2.0
+appVersion: 1.4.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.0/cray-power-control/values.yaml
+++ b/charts/v1.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.2.0
-  testVersion: 1.2.0
+  appVersion: 1.4.0
+  testVersion: 1.4.0
 
 tests:
   image:

--- a/charts/v1.1/cray-power-control/Chart.yaml
+++ b/charts/v1.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.1.2
+version: 1.1.3
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.3.0
+appVersion: 1.4.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.1/cray-power-control/values.yaml
+++ b/charts/v1.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.3.0
-  testVersion: 1.3.0
+  appVersion: 1.4.0
+  testVersion: 1.4.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -6,6 +6,7 @@ chartVersionToCSMVersion:
   ">=0.1.0": "~1.3.0"
   ">=0.2.0": "~1.3.0"
   ">=1.0.0": "~1.4.0"
+  ">=1.1.0": "~1.6.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -18,9 +19,11 @@ chartVersionToApplicationVersion:
   "1.0.0": "1.0.0"
   "1.0.1": "1.0.0"
   "1.0.2": "1.2.0"
+  "1.0.3": "1.4.0"
   "1.1.0": "1.0.0"
   "1.1.1": "1.2.0"
   "1.1.2": "1.3.0"
+  "1.1.3": "1.4.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

PCS power-status was showing managementStatus as 'undefined' instead of 'unavailable' when the controller is unresponsive.

## Issues and Related PRs

* Resolves [CASMHMS-5887](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5887)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/27

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable