### PR TITLE
Add the version to PCS's URL when inside the service mesh.

### DIFF
--- a/changelog/v1.2.md
+++ b/changelog/v1.2.md
@@ -1,0 +1,12 @@
+# Changelog for v1.2
+
+All notable changes to this project for v1.2.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2023-02-08
+
+### Changed
+- CASMHMS-5917 - Updated PCS image to 1.5.0 to handle `/v1/*` and `/*` URLs
+- CASMHMS-5917 - Updated PCS ingress to point `apis/power-control/v1` to `/v1`

--- a/charts/v1.2/cray-power-control/Chart.yaml
+++ b/charts/v1.2/cray-power-control/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: "cray-power-control"
+version: 1.2.0
+description: "Kubernetes resources for cray-power-control"
+home: "https://github.com/Cray-HPE/hms-power-control-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-power-control"
+dependencies:
+  - name: cray-service
+    version: "~9.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: 1.5.0
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v1.2/cray-power-control/templates/configmaps.yaml
+++ b/charts/v1.2/cray-power-control/templates/configmaps.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-power-control-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"

--- a/charts/v1.2/cray-power-control/templates/tests/test-functional.yaml
+++ b/charts/v1.2/cray-power-control/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v1.2/cray-power-control/templates/tests/test-smoke.yaml
+++ b/charts/v1.2/cray-power-control/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]

--- a/charts/v1.2/cray-power-control/values.yaml
+++ b/charts/v1.2/cray-power-control/values.yaml
@@ -1,0 +1,117 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+global:
+  appVersion: 1.5.0
+  testVersion: 1.5.0
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-hmth-test
+    pullPolicy: IfNotPresent
+cray-etcd-base:
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-power-control-etcd"
+    nameOverride: "cray-power-control-etcd"
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-power-control
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdWaitContainer: true
+  containers:
+    cray-power-control:
+      name: "cray-power-control"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/stable/cray-power-control"
+      resources:
+        limits:
+          cpu: "4"
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      ports:
+        - name: http
+          containerPort: 28007
+      env:
+        - name: LOG_LEVEL
+          value: "DEBUG"
+        - name: SMS_SERVER
+          value: "http://cray-smd"
+        - name: VAULT_ENABLED
+          value: "true"
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: TRS_IMPLEMENTATION
+          value: "LOCAL"
+        - name: SERVICE_RESERVATION_VERBOSITY
+          value: "ERROR"
+        - name: HSMLOCK_ENABLED
+          value: "true"
+        - name: STORAGE
+          value: "ETCD"
+        - name: PCS_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: cray-power-control-cacert-info
+              key: CA_URI
+      livenessProbe:
+        httpGet:
+          port: 28007
+          path: /liveness
+        initialDelaySeconds: 15
+        periodSeconds: 5
+      readinessProbe:
+        httpGet:
+          port: 28007
+          path: /readiness
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 25
+      volumeMounts:
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+  ingress:
+    enabled: true
+    uri: "/v1/"
+    prefix: "/apis/power-control/v1/"

--- a/charts/v1.2/cray-power-control/values.yaml
+++ b/charts/v1.2/cray-power-control/values.yaml
@@ -93,13 +93,13 @@ cray-service:
       livenessProbe:
         httpGet:
           port: 28007
-          path: /liveness
+          path: /v1/liveness
         initialDelaySeconds: 15
         periodSeconds: 5
       readinessProbe:
         httpGet:
           port: 28007
-          path: /readiness
+          path: /v1/readiness
         initialDelaySeconds: 30
         periodSeconds: 60
         timeoutSeconds: 25

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -24,6 +24,7 @@ chartVersionToApplicationVersion:
   "1.1.1": "1.2.0"
   "1.1.2": "1.3.0"
   "1.1.3": "1.4.0"
+  "1.2.0": "1.5.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
CASMHMS-5917

## Summary and Scope

This changes PCS to handle `/v1/*` as well as `/*` so that the URI for inside the service mesh includes a version, `http://cray-power-control/v1/*`. The `/*` handling is left in for compatibility.

The PCS chart has been updated so that ingress from outside the service mesh points to `/v1`

## Issues and Related PRs

* Resolves [CASMHMS-5917](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5917)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/28

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable