### PR TITLE
CASMHMS-5924 Fix PCS test bug for cases with multiple verify response functions

### DIFF
--- a/changelog/v1.2.md
+++ b/changelog/v1.2.md
@@ -5,6 +5,11 @@ All notable changes to this project for v1.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2023-02-28
+
+### Fixed
+- Fixed bug in CT tests that use multiple verify response functions
+
 ## [1.2.0] - 2023-02-08
 
 ### Changed

--- a/charts/v1.2/cray-power-control/Chart.yaml
+++ b/charts/v1.2/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.2.0
+version: 1.2.1
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.5.0
+appVersion: 1.6.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.2/cray-power-control/values.yaml
+++ b/charts/v1.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.5.0
-  testVersion: 1.5.0
+  appVersion: 1.6.0
+  testVersion: 1.6.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -25,6 +25,7 @@ chartVersionToApplicationVersion:
   "1.1.2": "1.3.0"
   "1.1.3": "1.4.0"
   "1.2.0": "1.5.0"
+  "1.2.1": "1.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

This PR fixes a bug in multiple CT tests where certain validation functions were being silently skipped.

### Issues and Related PRs

* Partially resolves CASMHMS-5924.

### Testing

This change was tested locally using the HMS simulation environment by injecting failures into the test cases that previously had checks that were being skipped and verifying that they now correctly cause failures instead of always passing.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.