### PR TITLE
Fix hang in PCS hardware scan

### DIFF
--- a/changelog/v1.2.md
+++ b/changelog/v1.2.md
@@ -5,6 +5,11 @@ All notable changes to this project for v1.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2023-03-28
+
+### Fixed
+- CASMHMS-5919 - Fixed issue causing PCS hardware scan to hang.
+
 ## [1.2.1] - 2023-02-28
 
 ### Fixed

--- a/charts/v1.2/cray-power-control/Chart.yaml
+++ b/charts/v1.2/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 1.2.1
+version: 1.2.2
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.6.0
+appVersion: 1.7.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v1.2/cray-power-control/values.yaml
+++ b/charts/v1.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.6.0
-  testVersion: 1.6.0
+  appVersion: 1.7.0
+  testVersion: 1.7.0
 
 tests:
   image:
@@ -68,7 +68,7 @@ cray-service:
           containerPort: 28007
       env:
         - name: LOG_LEVEL
-          value: "DEBUG"
+          value: "INFO"
         - name: SMS_SERVER
           value: "http://cray-smd"
         - name: VAULT_ENABLED

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -26,6 +26,7 @@ chartVersionToApplicationVersion:
   "1.1.3": "1.4.0"
   "1.2.0": "1.5.0"
   "1.2.1": "1.6.0"
+  "1.2.2": "1.7.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

This fixes a bug in PCS's hardware scan causing it to hang if only components without ComponentEndpoint entries exist in HSM.

This also adjusts the verbosity of log messages for PCS status APIs (GetLiveness, GetReadiness, and GetHealth).

## Issues and Related PRs

* Resolves [CASMHMS-5919](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5919)

## Testing

For testing see https://github.com/Cray-HPE/hms-power-control/pull/30

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable