### PR TITLE
Add RTS management switches to PCS

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,11 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2023-05-03
+
+### Added
+- Added RTS management switches to PCS
+
 ## [2.0.0] - 2023-04-10
 
 ### Changed

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.0
+version: 2.0.1
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.8.0
+appVersion: 1.9.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.8.0
-  testVersion: 1.8.0
+  appVersion: 1.9.0
+  testVersion: 1.9.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -30,6 +30,7 @@ chartVersionToApplicationVersion:
   "1.2.2": "1.7.0"
   "1.2.3": "1.8.0"
   "2.0.0": "1.8.0"
+  "2.0.1": "1.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

This updates the PCS image version for CASMHMS-5952 - Add RTS management switches to PCS.

## Issues and Related PRs

* Resolves [CASMHMS-5952](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5952)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/32

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable