### PR TITLE
CASMTRIAGE-5390 Add disasterRecovery section

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,11 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2023-05-18
+
+### Added
+- Added disasterRecovery section to chart
+
 ## [2.0.1] - 2023-05-03
 
 ### Added

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.1
+version: 2.0.2
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -21,6 +21,12 @@ cray-etcd-base:
     enabled: true
     fullnameOverride: "cray-power-control-bitnami-etcd"
     nameOverride: "cray-power-control-bitnami-etcd"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-power-control-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -31,6 +31,7 @@ chartVersionToApplicationVersion:
   "1.2.3": "1.8.0"
   "2.0.0": "1.8.0"
   "2.0.1": "1.9.0"
+  "2.0.2": "1.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Add required disasterRecovery chart section to allow for ETCD backups.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5390](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5390)

## Testing

Tested on:

  * `drax`

Test description:

Copied chart to drax and initiated a helm upgrade. Verified deployed chart contained the expected changes.

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable