### PR TITLE
Utilize HSM PowerMaps in PCS

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,15 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2023-06-08
+
+### Added
+- Functionality to utilize PowerMaps from HSM when available.
+
+### Fixed
+- Memory leak in transitions and power-cap domain functions.
+- power-cap naming mismatch between snapshots and parsed HSM data.
+
 ## [2.0.2] - 2023-05-18
 
 ### Added

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.2
+version: 2.0.3
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.9.0
+appVersion: 1.10.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.9.0
-  testVersion: 1.9.0
+  appVersion: 1.10.0
+  testVersion: 1.10.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.8.0"
   "2.0.1": "1.9.0"
   "2.0.2": "1.9.0"
+  "2.0.3": "1.10.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

This changes PCS to utilize PowerMaps from HSM when available to honor power hierarchy failures when PDU outlets are involved.

This fixes a memory leak in the transition and power-cap domain functions.

This fixes a naming inconsistency between snapshots and parsing HSM data inside PCS.

## Issues and Related PRs

* Resolves [CASMHMS-5995](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5995)
* Resolves [CASMHMS-5998](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5998)
* Resolves [CASMHMS-5996](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5996)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/34

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable