### PR TITLE
Make record expiration and the maximum number of completed records configurable

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -1,0 +1,17 @@
+# Changelog for v2.1
+
+All notable changes to this project for v2.1.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2023-09-28
+
+### Added
+
+- Added MAX_NUM_COMPLETED env to control the maximum number of non-expired completed transition or power capping records to keep.
+- Added EXPIRE_TIME_MINS env to control the lifetime of completed transition or power capping records.
+
+### Changed
+
+- Reduced ETCD storage size of completed power cap tasks and transitions.

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: "cray-power-control"
+version: 2.1.0
+description: "Kubernetes resources for cray-power-control"
+home: "https://github.com/Cray-HPE/hms-power-control-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-power-control"
+dependencies:
+  - name: cray-service
+    version: "~10.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: 2.0.0
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/templates/configmaps.yaml
+++ b/charts/v2.1/cray-power-control/templates/configmaps.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-power-control-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"

--- a/charts/v2.1/cray-power-control/templates/tests/test-functional.yaml
+++ b/charts/v2.1/cray-power-control/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v2.1/cray-power-control/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-power-control/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -1,0 +1,147 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+global:
+  appVersion: 2.0.0
+  testVersion: 2.0.0
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-hmth-test
+    pullPolicy: IfNotPresent
+cray-etcd-base:
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-power-control-bitnami-etcd"
+    nameOverride: "cray-power-control-bitnami-etcd"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-power-control-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
+    extraEnvVars:
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "4200"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "21000"
+      - name: ETCD_MAX_SNAPSHOTS
+        value: "5"
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "10737418240"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "10000"
+      - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+        value: "24"
+      - name: ETCD_DISABLE_PRESTOP
+        value: "yes"
+    extraVolumes:
+      - configMap:
+          defaultMode: 420
+          name: cray-power-control-bitnami-etcd-config
+        name: etcd-config
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-power-control
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdWaitContainer: true
+  containers:
+    cray-power-control:
+      name: "cray-power-control"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/stable/cray-power-control"
+      resources:
+        limits:
+          cpu: "4"
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      ports:
+        - name: http
+          containerPort: 28007
+      env:
+        - name: LOG_LEVEL
+          value: "INFO"
+        - name: SMS_SERVER
+          value: "http://cray-smd"
+        - name: VAULT_ENABLED
+          value: "true"
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: TRS_IMPLEMENTATION
+          value: "LOCAL"
+        - name: SERVICE_RESERVATION_VERBOSITY
+          value: "ERROR"
+        - name: HSMLOCK_ENABLED
+          value: "true"
+        - name: STORAGE
+          value: "ETCD"
+        - name: PCS_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: cray-power-control-cacert-info
+              key: CA_URI
+        - name: MAX_NUM_COMPLETED
+          value: 20000
+        - name: EXPIRE_TIME_MINS
+          value: 1440
+      livenessProbe:
+        httpGet:
+          port: 28007
+          path: /v1/liveness
+        initialDelaySeconds: 15
+        periodSeconds: 5
+      readinessProbe:
+        httpGet:
+          port: 28007
+          path: /v1/readiness
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 25
+      volumeMounts:
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+  ingress:
+    enabled: true
+    uri: "/v1/"
+    prefix: "/apis/power-control/v1/"

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -8,6 +8,7 @@ chartVersionToCSMVersion:
   ">=1.0.0": "~1.4.0"
   ">=1.1.0": "~1.5.0"
   ">=2.0.0": "~1.5.0"
+  ">=2.1.0": "~1.6.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -34,6 +35,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.9.0"
   "2.0.3": "1.10.0"
   "2.0.4": "1.10.0"
+  "2.1.0": "2.0.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

PCS's ETCD volume usage can grow large if there are too many power cap task or transition requests in a 24-hour period. To mitigate this issue, I reduced the size of completed records and made the maximum number of completed records to keep and the duration to keep records configurable

## Issues and Related PRs

* Resolves [CASMHMS-6058](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6058)

## Testing

For testing, see https://github.com/Cray-HPE/hms-power-control/pull/37

## Risks and Mitigations

This makes completed transition and power-cap records incompatible with older versions of PCS (v1.x.x) due to the change in the way they are stored in ETCD to reduced their size.

It does not break the ability to downgrade PCS from v2.x.x to v1.x.x. However, if PCS is downgraded, the older PCS (v1.x.x) will not be able to read some of the information in the completed records.

We think this is acceptable since downgrades generally happen when there's a problem with the system and the ability to view the completed records is not needed since there should not be any ongoing transition or power capping operations during a downgrade. Also, all previously existing records are purged after 24 hours by default anyway. So the issue would be transient.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable