### PR TITLE
CASMHMS-6058 Put quotes around numbers of new variables

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2023-10-03
+
+### Fixed
+
+- New variables added in previous chart require quotes around them
+
 ## [2.1.0] - 2023-09-28
 
 ### Added

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -117,9 +117,9 @@ cray-service:
               name: cray-power-control-cacert-info
               key: CA_URI
         - name: MAX_NUM_COMPLETED
-          value: 20000
+          value: "20000"
         - name: EXPIRE_TIME_MINS
-          value: 1440
+          value: "1440"
       livenessProbe:
         httpGet:
           port: 28007

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -36,6 +36,7 @@ chartVersionToApplicationVersion:
   "2.0.3": "1.10.0"
   "2.0.4": "1.10.0"
   "2.1.0": "2.0.0"
+  "2.1.1": "2.0.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

New variables added in v2.1 did not have quotes around them. This caused a failure during vShasta install. Added the quotes.

## Issues and Related PRs

* Resolves [CASMHMS-6058](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6058)

## Testing

Tested on:

  * Beau - vShasta

Test description:

Verified the new values were properly being picked up when the service is upgraded.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

Minimal risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable