### PR TITLE
CASMHMS-6121 pick up new cray etcd-base-chart 2.0

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2023-12-21
+
+### Changed
+
+- New environmental variable for ETCD cluster
+
 ## [2.0.4] - 2023-06-23
 
 ### Added

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.4
+version: 2.0.5
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.10.0
+appVersion: 2.0.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 1.10.0
-  testVersion: 1.10.0
+  appVersion: 2.0.0
+  testVersion: 2.0.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -34,6 +34,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.9.0"
   "2.0.3": "1.10.0"
   "2.0.4": "1.10.0"
+  "2.0.5": "2.0.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Bump version to pick up new cray-etcd-base chart with a fixed compaction algorithm. Bumped the PCS version to 2.0.0 to include improved etcd usage code.

## Issues and Related PRs

* Resolves [CASMHMS-6121](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6121)

## Testing

Tested on:

  * `lemondrop`

Test description:

Upgraded the PCS chart that included the latest cray-etcd-base chart with the fixed compaction code. Compaction runs every hour, verified that the PCS etcd got compacted and defragmented as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - need to let the code soak for extra validation

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable