### PR TITLE
CASMHMS-6131: Remove references to unused HSNBoard component in PCS

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2024-02-27
+
+### Removed
+
+- CASMHMS-6131: Remove unused HSNBoard related code
+
 ## [2.1.2] - 2023-12-20
 
 ### Changed

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.0.0
+appVersion: 2.1.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.0.0
-  testVersion: 2.0.0
+  appVersion: 2.1.0
+  testVersion: 2.1.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -39,6 +39,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "2.0.0"
   "2.1.1": "2.0.0"
   "2.1.2": "2.0.0"
+  "2.1.3": "2.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

This PR removes references to the HSNBoard component in PCS as it is no longer needed.  This
codewas causing issues for a development version of the SAT tool that was replacing its use of
CAPMC with PCS.

Adopted app version 2.1.0

CASMHMS-6131

## Issues and Related PRs

Resolves CASMHMS-6131

## Testing

This problem was only present with a development version of the SAT tool with temporary
changes to replace its use of CAPMC with PCS.  The SAT team took my changes via a container
and chart that I provided them to test with their changes.  They tested both sets of changes
together successfully on baldar on 2/26/2024.

Tested on:

  * baldar