### PR TITLE
CASMHMS-6146: Generate correct PowerCapURI for Olympus hardware

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- CASMHMS-6146: Ignore PowerCapURI in base comp when doing Controls pcap
+- CASMHMS-6146: Generate correct PowerCapURI for Olympus hardware
 
 ## [2.0.6] - 2024-02-27
 

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.7] - 2024-05-06
+
+### Fixed
+
+- CASMHMS-6146: Ignore PowerCapURI in base comp when doing Controls pcap
+
 ## [2.0.6] - 2024-02-27
 
 ### Removed

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- CASMHMS-6146: Ignore PowerCapURI in base comp when doing Controls pcap
+- CASMHMS-6146: Generate correct PowerCapURI for Olympus hardware
 
 ## [2.1.3] - 2024-02-27
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2024-05-06
+
+### Fixed
+
+- CASMHMS-6146: Ignore PowerCapURI in base comp when doing Controls pcap
+
 ## [2.1.3] - 2024-02-27
 
 ### Removed

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.6
+version: 2.0.7
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.1.0
+appVersion: 2.2.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.1.0
-  testVersion: 2.1.0
+  appVersion: 2.2.0
+  testVersion: 2.2.0
 
 tests:
   image:

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.3
+version: 2.1.4
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.1.0
+appVersion: 2.2.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.1.0
-  testVersion: 2.1.0
+  appVersion: 2.2.0
+  testVersion: 2.2.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -37,10 +37,12 @@ chartVersionToApplicationVersion:
   "2.0.4": "1.10.0"
   "2.0.5": "2.0.0"
   "2.0.6": "2.1.0"
+  "2.0.7": "2.2.0"
   "2.1.0": "2.0.0"
   "2.1.1": "2.0.0"
   "2.1.2": "2.0.0"
   "2.1.3": "2.1.0"
+  "2.1.4": "2.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

PCS has been using the older /Power redfish URL to generate PowerCapURI for /Controls.Deep on all Olympus hardware.  The issue with that is that newer hardware (eg. Blanca Peak, Parry Peak) no longer have the /Power URL.  The fix here is to take one of the Controls URLs (eg. /Controls/NodePowerLimit) and use it to construct the PowerCapURI for /Controls.Deep.  For simplicity and clarity in the code, the fix does this for all Olympus hardware even though older hardware still have the /Power URL.

Additionally, two health checks in the power cap path were converted to check for this newly constructed PowerCapURI rather than key off the older /Power URL that no longer exists.

Adopted app version 2.2.0 for CSM 1.5 (helm chart 2.0.7)
Adopted app version 2.2.0 for CSM 1.6 (helm chart 2.1.4)

## Issues and Related PRs

* Resolves CASMHMS-6146

## Testing

Tested on tyr against the Windom, Bard Peak, Blanca Peak, and Parry Peak platforms.

For Windom, Blanca Peak, and Parry Peak I set and cleared a power cap for "Power Node Limit"

For Bard Peak I set and cleared a power cap for "Accelerator3 Power Limit"

I also verified that I could set a Parry Peak power cap for two nodes at the same time with a single command line invocation.

I also tested snapshots for all platforms using '--xnames all' to verify all URI's were valid.

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? Yes
- Was upgrade tested? Yes via 'helm upgrade'
- Was downgrade tested? Yes via 'helm rollback'

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable