### PR TITLE
CASMHMS-6156: Add POST option to get power states to avoid size limitations with GET parameters

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,7 +5,13 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.7] - 2024-05-06
+## [2.0.8] - 2024-03-27
+
+### Added
+
+- CASMCMS-8952: Add ability to query power status using POST request.
+
+## [2.0.7] - 2024-03-06
 
 ### Fixed
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,7 +5,13 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.4] - 2024-05-06
+## [2.1.5] - 2024-03-27
+
+### Added
+
+- CASMCMS-8952: Add ability to query power status using POST request.
+
+## [2.1.4] - 2024-03-06
 
 ### Fixed
 

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.7
+version: 2.0.8
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.2.0
+appVersion: 2.3.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.2.0
-  testVersion: 2.2.0
+  appVersion: 2.3.0
+  testVersion: 2.3.0
 
 tests:
   image:

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.4
+version: 2.1.5
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.2.0
+appVersion: 2.3.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.2.0
-  testVersion: 2.2.0
+  appVersion: 2.3.0
+  testVersion: 2.3.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -38,11 +38,13 @@ chartVersionToApplicationVersion:
   "2.0.5": "2.0.0"
   "2.0.6": "2.1.0"
   "2.0.7": "2.2.0"
+  "2.0.8": "2.3.0"
   "2.1.0": "2.0.0"
   "2.1.1": "2.0.0"
   "2.1.2": "2.0.0"
   "2.1.3": "2.1.0"
   "2.1.4": "2.2.0"
+  "2.1.5": "2.3.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

See source PR for full explanation of the PCS changes associated with this, and the testing that was done:
https://github.com/Cray-HPE/hms-power-control/pull/41

Adopted app version 2.3.0 for CSM 1.5 (helm chart 2.0.8)
Adopted app version 2.3.0 for CSM 1.6 (helm chart 2.1.5)

## Issues and Related PRs

* Resolves [CASMHMS-6156](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6156)
* Required for [CASMCMS-8952](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8952)

## Testing

See source PR for full explanation of the PCS changes associated with this, and the testing that was done:
https://github.com/Cray-HPE/hms-power-control/pull/41

For this PR specifically, I also made sure I could upgrade and deploy the new charts on mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
