### PR TITLE
CASMHMS-6148: Parse PowerConsumedWatts for any data type and intialize pcap min/max appropriately

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2024-04-15
+
+### Added
+
+- Parse PowerConsumedWatts for any data type
+
 ## [2.0.8] - 2024-03-27
 
 ### Added

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Parse PowerConsumedWatts for any data type and intialize pcap min/max appropriately
+- Parse PowerConsumedWatts for any data type and intialize pcap min/max appropriately 
 
 ## [2.0.8] - 2024-03-27
 

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,11 +5,11 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.9] - 2024-04-15
+## [2.0.9] - 2024-04-24
 
 ### Added
 
-- Parse PowerConsumedWatts for any data type
+- Parse PowerConsumedWatts for any data type and intialize pcap min/max appropriately
 
 ## [2.0.8] - 2024-03-27
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2024-04-15
+
+### Added
+
+- Parse PowerConsumedWatts for any data type
+
 ## [2.1.5] - 2024-03-27
 
 ### Added

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,11 +5,11 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.6] - 2024-04-15
+## [2.1.6] - 2024-04-24
 
 ### Added
 
-- Parse PowerConsumedWatts for any data type
+- Parse PowerConsumedWatts for any data type and intialize pcap min/max appropriately
 
 ## [2.1.5] - 2024-03-27
 

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.8
+version: 2.0.9
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.3.0
+appVersion: 2.4.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.3.0
-  testVersion: 2.3.0
+  appVersion: 2.4.0
+  testVersion: 2.4.0
 
 tests:
   image:

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.5
+version: 2.1.6
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.3.0
+appVersion: 2.4.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.3.0
-  testVersion: 2.3.0
+  appVersion: 2.4.0
+  testVersion: 2.4.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -39,12 +39,14 @@ chartVersionToApplicationVersion:
   "2.0.6": "2.1.0"
   "2.0.7": "2.2.0"
   "2.0.8": "2.3.0"
+  "2.0.9": "2.4.0"
   "2.1.0": "2.0.0"
   "2.1.1": "2.0.0"
   "2.1.2": "2.0.0"
   "2.1.3": "2.1.0"
   "2.1.4": "2.2.0"
   "2.1.5": "2.3.0"
+  "2.1.6": "2.4.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

The Paradise redfish Power endpoint presents the consumed watts value as a float. All prior platforms have presented it as an integer value and thus the PCS data structure for holding it declared it as an int. This caused json.Unmarshal() to fail on Paradise because it enforces strict type checking.

The fix here is to change the int type to an interface{} type so that it can hold a value of any type. We then convert any floats we read to an int (by rounding). We chose to do this rather than simply changing the type from an int to a float so that we don't break any customer code that may be doing the same thing we were doing (expecting an int rather than a float).

Additionally, this PR contains a fix to initialize the power cap min/max values to -1.  This is necessary in order for requests against non-oem platforms to work properly in doPowerCapTask() where checks are made against these values.

Adopted app version 2.4.0 for CSM 1.5.2 (helm chart 2.0.9)
Adopted app version 2.4.0 for CSM 1.6 (helm chart 2.1.6)

## Issues and Related PRs

* Resolves CASMHMS-6148

## Testing

Tested on:

  * tyr

Test description:

With a patched SMD in place, verified that PCS would convert floats to ints properly when ran against Paradise nodes.  Then verified that PCS could power cap both Paradise and Bard Peak compute nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable