### PR TITLE
CASMHMS-6261: Updated dependences for Kubernetes 1.24

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~10.0.6
+- Update cray-service chart to ~11.0.0
 
 ## [2.1.7] - 2024-07-10
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~11.0.0
+- Update cray-service chart to ~11.0
 
 ## [2.1.7] - 2024-07-10
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.8] - 2024-08-30
+
+### Changed
+
+- Update cray-service chart to ~10.0.6
+
 ## [2.1.7] - 2024-07-10
 
 ### Changed

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-power-control"
 dependencies:
   - name: cray-service
-    version: "~11.0.0"
+    version: "~11.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-etcd-base
     version: "~1.2"

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.7
+version: 2.1.8
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-power-control"
 dependencies:
   - name: cray-service
-    version: "~10.0"
+    version: "~10.0.6"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-etcd-base
     version: "~1.2"

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-power-control"
 dependencies:
   - name: cray-service
-    version: "~10.0.6"
+    version: "~11.0.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-etcd-base
     version: "~1.2"

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -1,6 +1,12 @@
 ---
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
+  # Summary:
+  #   Chart Version: 0.0.1 <= x.y.z < 1.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
+  #   Chart Version: 1.0.0 <= x.y.z < 1.1.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
+  #   Chart Version: 1.1.0 <= x.y.z < 2.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  #   Chart Version: 2.1.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #
   # Chart version: CSM version
   ">=0.0.1": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=0.1.0": "~1.3.0"
@@ -8,7 +14,7 @@ chartVersionToCSMVersion:
   ">=1.0.0": "~1.4.0"
   ">=1.1.0": "~1.5.0"
   ">=2.0.0": "~1.5.0"
-  ">=2.1.0": "~1.6.0" # CSM 1.6.0 or later
+  ">=2.1.0": "~1.6.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -8,7 +8,7 @@ chartVersionToCSMVersion:
   ">=1.0.0": "~1.4.0"
   ">=1.1.0": "~1.5.0"
   ">=2.0.0": "~1.5.0"
-  ">=2.1.0": "~1.6.0"
+  ">=2.1.0": "~1.6.0" # CSM 1.6.0 or later
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -48,6 +48,7 @@ chartVersionToApplicationVersion:
   "2.1.5": "2.3.0"
   "2.1.6": "2.4.0"
   "2.1.7": "2.4.0"
+  "2.1.8": "2.4.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

In CSM 1.6 Kubernetes is being updated to 1.24

- Updated the cray-service chart to 11.0.0

Adopted helm chart 2.1.8 for this.  There was no change in app version.

## Issues and Related PRs

* Resolves [CASMHMS-6261](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6261)

## Testing

Tested on:

  * `fanta` (running Kubernetes v1.24.17)

Test description:

All testing was done with the new cray-service 10.0.6.  After testing completed, was asked to use 11.0.0 instead of 10.0.6 but was informed that no testing of 11.0.0 was required to be done if already tested with 10.0.6 because it is the exact same, just a different version number.

- Upgraded to new chart with 'helm upgrade'
- Because pods don't restart after upgrade if there was no container change, manually restarted them with 'kubectl rollout restart deployment'
- Verified no errors in chart upgrade or restart of pods
- Ran test suite 'run_hms_ct_tests.sh -t pcs' and verified no failures
- Checked logs from service to verify nothing unusual present

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable