### PR TITLE
CASMHMS-6299: Fix PCS/TRS resource leaks and scaling issues

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -9,19 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update timeoutSeconds for liveness probe in helm chart from 1 to 3
 - Updated hms-trs-app-api vendor code (bug fixes and enhancements)
-- Passed PCS's log level through to TRS to match PCS
+- Passed PCS's log level through to TRS to match PCS's
 - Configured TRS to use connection pools for status requests to BMCs
-- Did not modify transition and power cap paths to use connection pools
 - Renamed PCS_STATUS_HTTP_TIMEOUT to PCS_STATUS_TIMEOUT as it is not an
   http timeout
 - Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables
-  which allow overriding connection pool settings in TRS
+  which allow overriding PCS's connection pool settings in TRS
 - The above variables are configurable on PCS's helm chart
-- Fixed many resource leaks associated with TRS and http requests
+- Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid
   https://github.com/golang/go/issues/59017
-- Update timeoutSeconds for liveness probe in helm chart from 1 to 2
 
 ## [2.0.10] - 2024-10-25
 

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   http timeout
 - Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables
   which allow overriding PCS's connection pool settings in TRS
+- Added PCS_BASE_TRS_TASK_TIMEOUT env variable which allows the timeout
+  for power transitions and capping to be configured
 - The above variables are configurable on PCS's helm chart
 - Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,15 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.11] - 2024-11-18
+
+### Changed
+
+- Updated hms-trs-app-api vendor code (bug fixes and configurable connection pool support)
+- Added support for non-default sized connection pools
+- Added ability to configure connection pools through PCS helm chart
+- Fixed various resource leaks associated with TRS usage
+
 ## [2.0.10] - 2024-10-25
 
 ### Changed

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,14 +5,20 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.11] - 2024-11-18
+## [2.0.11] - 2024-11-25
 
 ### Changed
 
-- Updated hms-trs-app-api vendor code (bug fixes and configurable connection pool support)
-- Added support for non-default sized connection pools
-- Added ability to configure connection pools through PCS helm chart
-- Fixed various resource leaks associated with TRS usage
+- Updated hms-trs-app-api vendor code (bug fixes and enhancements)
+- Passed PCS's log level through to TRS to match PCS
+- Configured TRS to use connection pools for status requests to BMCs
+- Did not modify transition and power cap paths to use connection pools
+- Renamed PCS_STATUS_HTTP_TIMEOUT to PCS_STATUS_TIMEOUT as it is not an
+  http timeout
+- Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables
+  which allow overriding connection pool settings in TRS
+- The above variables are configurable on PCS's helm chart
+- Fixed many resource leaks associated with TRS and http requests
 
 ## [2.0.10] - 2024-10-25
 

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed many resource leaks associated with TRS and http requests
 - Update required version of Go to 1.23 to avoid
   https://github.com/golang/go/issues/59017
+- Update timeoutSeconds for liveness probe in helm chart from 1 to 2
 
 ## [2.0.10] - 2024-10-25
 

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which allow overriding connection pool settings in TRS
 - The above variables are configurable on PCS's helm chart
 - Fixed many resource leaks associated with TRS and http requests
+- Update required version of Go to 1.23 to avoid
+  https://github.com/golang/go/issues/59017
 
 ## [2.0.10] - 2024-10-25
 

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for power transitions and capping to be configured
 - The above variables are configurable on PCS's helm chart
 - At PCS start time, log all env variables that were set
+- Added PodName global to facilitate easier debug of log messages
 - Log start and end of large batched requests to BMCs
 - Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PCS_BASE_TRS_TASK_TIMEOUT env variable which allows the timeout
   for power transitions and capping to be configured
 - The above variables are configurable on PCS's helm chart
+- At PCS start time, log all env variables that were set
+- Log start and end of large batched requests to BMCs
 - Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid
   https://github.com/golang/go/issues/59017

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   http timeout
 - Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables
   which allow overriding PCS's connection pool settings in TRS
+- Added PCS_BASE_TRS_TASK_TIMEOUT env variable which allows the timeout
+  for power transitions and capping to be configured
 - The above variables are configurable on PCS's helm chart
 - Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,14 +5,20 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.10] - 2024-11-18
+## [2.1.10] - 2024-11-25
 
 ### Changed
 
-- Updated hms-trs-app-api vendor code (bug fixes and configurable connection pool support)
-- Added support for non-default sized connection pools
-- Added ability to configure connection pools through PCS helm chart
-- Fixed various resource leaks associated with TRS usage
+- Updated hms-trs-app-api vendor code (bug fixes and enhancements)
+- Passed PCS's log level through to TRS to match PCS
+- Configured TRS to use connection pools for status requests to BMCs
+- Did not modify transition and power cap paths to use connection pools
+- Renamed PCS_STATUS_HTTP_TIMEOUT to PCS_STATUS_TIMEOUT as it is not an
+  http timeout
+- Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables
+  which allow overriding connection pool settings in TRS
+- The above variables are configurable on PCS's helm chart
+- Fixed many resource leaks associated with TRS and http requests
 
 ## [2.1.9] - 2024-10-25
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which allow overriding connection pool settings in TRS
 - The above variables are configurable on PCS's helm chart
 - Fixed many resource leaks associated with TRS and http requests
+- Update required version of Go to 1.23 to avoid
+  https://github.com/golang/go/issues/59017
 
 ## [2.1.9] - 2024-10-25
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed many resource leaks associated with TRS and http requests
 - Update required version of Go to 1.23 to avoid
   https://github.com/golang/go/issues/59017
+- Update timeoutSeconds for liveness probe in helm chart from 1 to 2
 
 ## [2.1.9] - 2024-10-25
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,15 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.10] - 2024-11-18
+
+### Changed
+
+- Updated hms-trs-app-api vendor code (bug fixes and configurable connection pool support)
+- Added support for non-default sized connection pools
+- Added ability to configure connection pools through PCS helm chart
+- Fixed various resource leaks associated with TRS usage
+
 ## [2.1.9] - 2024-10-25
 
 ### Changed

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for power transitions and capping to be configured
 - The above variables are configurable on PCS's helm chart
 - At PCS start time, log all env variables that were set
+- Added PodName global to facilitate easier debug of log messages
 - Log start and end of large batched requests to BMCs
 - Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -9,19 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update timeoutSeconds for liveness probe in helm chart from 1 to 3
 - Updated hms-trs-app-api vendor code (bug fixes and enhancements)
-- Passed PCS's log level through to TRS to match PCS
+- Passed PCS's log level through to TRS to match PCS's
 - Configured TRS to use connection pools for status requests to BMCs
-- Did not modify transition and power cap paths to use connection pools
 - Renamed PCS_STATUS_HTTP_TIMEOUT to PCS_STATUS_TIMEOUT as it is not an
   http timeout
 - Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables
-  which allow overriding connection pool settings in TRS
+  which allow overriding PCS's connection pool settings in TRS
 - The above variables are configurable on PCS's helm chart
-- Fixed many resource leaks associated with TRS and http requests
+- Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid
   https://github.com/golang/go/issues/59017
-- Update timeoutSeconds for liveness probe in helm chart from 1 to 2
 
 ## [2.1.9] - 2024-10-25
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PCS_BASE_TRS_TASK_TIMEOUT env variable which allows the timeout
   for power transitions and capping to be configured
 - The above variables are configurable on PCS's helm chart
+- At PCS start time, log all env variables that were set
+- Log start and end of large batched requests to BMCs
 - Fixed many resource leaks associated with making http requests and using TRS
 - Update required version of Go to 1.23 to avoid
   https://github.com/golang/go/issues/59017

--- a/charts/v2.0/cray-power-control/Chart.yaml
+++ b/charts/v2.0/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.0.10
+version: 2.0.11
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.5.0
+appVersion: 2.6.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -130,6 +130,7 @@ cray-service:
           path: /v1/liveness
         initialDelaySeconds: 15
         periodSeconds: 5
+        timeoutSeconds: 2
       readinessProbe:
         httpGet:
           port: 28007

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -116,6 +116,8 @@ cray-service:
             configMapKeyRef:
               name: cray-power-control-cacert-info
               key: CA_URI
+        - name: PCS_BASE_TRS_TASK_TIMEOUT
+          value: "40"
         - name: PCS_STATUS_TIMEOUT
           value: "30"
         - name: PCS_STATUS_HTTP_RETRIES

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -130,7 +130,7 @@ cray-service:
           path: /v1/liveness
         initialDelaySeconds: 15
         periodSeconds: 5
-        timeoutSeconds: 2
+        timeoutSeconds: 3
       readinessProbe:
         httpGet:
           port: 28007

--- a/charts/v2.0/cray-power-control/values.yaml
+++ b/charts/v2.0/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.5.0
-  testVersion: 2.5.0
+  appVersion: 2.6.0
+  testVersion: 2.6.0
 
 tests:
   image:
@@ -116,6 +116,14 @@ cray-service:
             configMapKeyRef:
               name: cray-power-control-cacert-info
               key: CA_URI
+        - name: PCS_STATUS_TIMEOUT
+          value: "30"
+        - name: PCS_STATUS_HTTP_RETRIES
+          value: "3"
+        - name: PCS_MAX_IDLE_CONNS
+          value: "4000"
+        - name: PCS_MAX_IDLE_CONNS_PER_HOST
+          value: "4"
       livenessProbe:
         httpGet:
           port: 28007

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.9
+version: 2.1.10
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.5.0
+appVersion: 2.6.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.5.0
-  testVersion: 2.5.0
+  appVersion: 2.6.0
+  testVersion: 2.6.0
 
 tests:
   image:
@@ -120,6 +120,14 @@ cray-service:
           value: "20000"
         - name: EXPIRE_TIME_MINS
           value: "1440"
+        - name: PCS_STATUS_TIMEOUT
+          value: "30"
+        - name: PCS_STATUS_HTTP_RETRIES
+          value: "3"
+        - name: PCS_MAX_IDLE_CONNS
+          value: "4000"
+        - name: PCS_MAX_IDLE_CONNS_PER_HOST
+          value: "4"
       livenessProbe:
         httpGet:
           port: 28007

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -134,6 +134,7 @@ cray-service:
           path: /v1/liveness
         initialDelaySeconds: 15
         periodSeconds: 5
+        timeoutSeconds: 2
       readinessProbe:
         httpGet:
           port: 28007

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -120,6 +120,8 @@ cray-service:
           value: "20000"
         - name: EXPIRE_TIME_MINS
           value: "1440"
+        - name: PCS_BASE_TRS_TASK_TIMEOUT
+          value: "40"
         - name: PCS_STATUS_TIMEOUT
           value: "30"
         - name: PCS_STATUS_HTTP_RETRIES

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -134,7 +134,7 @@ cray-service:
           path: /v1/liveness
         initialDelaySeconds: 15
         periodSeconds: 5
-        timeoutSeconds: 2
+        timeoutSeconds: 3
       readinessProbe:
         httpGet:
           port: 28007

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -47,6 +47,7 @@ chartVersionToApplicationVersion:
   "2.0.8": "2.3.0"
   "2.0.9": "2.4.0"
   "2.0.10": "2.5.0"
+  "2.0.11": "2.6.0"
   "2.1.0": "2.0.0"
   "2.1.1": "2.0.0"
   "2.1.2": "2.0.0"
@@ -57,6 +58,7 @@ chartVersionToApplicationVersion:
   "2.1.7": "2.4.0"
   "2.1.8": "2.4.0"
   "2.1.9": "2.5.0"
+  "2.1.10": "2.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

A variety of changes related to PCS/TRS scaling issues being experienced in the field.  PCS details are as follows:

- Updated hms-trs-app-api vendor code (bug fixes and enhancements)
- Passed PCS's log level through to TRS to match PCS's
- Configured TRS to use connection pools for status requests to BMCs
- Renamed PCS_STATUS_HTTP_TIMEOUT to PCS_STATUS_TIMEOUT as it is not an http timeout
- Added PCS_MAX_IDLE_CONNS and PCS_MAX_IDLE_CONNS_PER_HOST env variables which allow overriding PCS's connection pool settings in TRS
- Added PCS_BASE_TRS_TASK_TIMEOUT env variable which allows the timeout for power transitions and capping to be configured
- The above variables are configurable on PCS's helm chart
- At PCS start time, log all env variables that were set
- Added PodName global to facilitate easier debug of log messages
- Log start and end of large batched requests to BMCs
- Fixed many resource leaks associated with making http requests and using TRS
- Update required version of Go to 1.23 to avoid [ https://github.com/golang/go/issues/59017](https://github.com/golang/go/issues/59017)

PCS helm chart changes:

- Update timeoutSeconds for liveness probe from 1 to 3
- Added following env variables to make it easier to configure them:

`        - name: PCS_BASE_TRS_TASK_TIMEOUT`
`          value: "40"`
`        - name: PCS_STATUS_TIMEOUT`
`          value: "30"`
`        - name: PCS_STATUS_HTTP_RETRIES`
`          value: "3"`
`       - name: PCS_MAX_IDLE_CONNS`
`          value: "4000"`
`        - name: PCS_MAX_IDLE_CONNS_PER_HOST`
`          value: "4"`

Adopted app version 2.6.0 for CSM 1.5.3 (helm chart 2.0.11)
Adopted app version 2.6.0 for CSM 1.6.1 (helm chart 2.1.10)

The PCS PR:  [https://github.com/Cray-HPE/hms-power-control/pull/57](https://github.com/Cray-HPE/hms-power-control/pull/57
)
The TRS PR:  [https://github.com/Cray-HPE/hms-trs-app-api/pull/11](https://github.com/Cray-HPE/hms-trs-app-api/pull/11)

## Issues and Related PRs

* Resolves [CASMHMS-6299](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6299)

## Testing

Test description:

Testing was two-pronged, unit testing (in TRS) and testing on a live system.  The majority of testing was done through the TRS unit test framework.  Extensive unit tests were added for all aspects of the connection lifecycle.

These changes were also tested alongside TRS changes on both `mug` and `rocket`.  Rocket is a CSM 1.5 system and mug is a CSM 1.6 system.  Additionally, mug was running several thousand simulated BMCs on compute nodes so that the scaling aspects of these changes could be tested.  All standard PCS operations were confirmed to continue working.

While we do not have any systems internally that are able to reproduce all of the problems at customer sites, we believe this change will go a long ways towards improving most of the issues being experienced.

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable