### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/.github/workflows/charts_lint_test_scan.yaml
+++ b/.github/workflows/charts_lint_test_scan.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   lint-test-scan:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v4
     with:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for ppprof
-- To enable pprof, set ENABLE_PPROF to 'true' in the Dockerfile
+- Added support for ppprof builds
 
 ## [2.1.10] - 2024-11-25
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.11] - 2025-01-08
+## [2.1.12] - 2025-01-08
 
 ### Added
 

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.11] - 2025-01-08
+
+### Added
+
+- Added support for ppprof
+- To enable pprof, set ENABLE_PPROF to 'true' in the Dockerfile
+
 ## [2.1.10] - 2024-11-25
 
 ### Changed

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.7.0
+appVersion: 2.7.0 # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.10
+version: 2.1.11
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.6.0
+appVersion: 2.7.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.7.0 # update pprof image version below as well
+appVersion: 2.7.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.1.11
+version: 2.1.12
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.7.0  # update pprof image version below as well
+appVersion: 2.8.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.7.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.8.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/Chart.yaml
+++ b/charts/v2.1/cray-power-control/Chart.yaml
@@ -17,4 +17,7 @@ maintainers:
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
 appVersion: 2.7.0
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-power-control-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.7.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -14,12 +14,6 @@ tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-hmth-test
     pullPolicy: IfNotPresent
-
-pprof:
-  image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof
-    pullPolicy: IfNotPresent
-
 cray-etcd-base:
   nameOverride: "cray-power-control"
   fullnameOverride: "cray-power-control"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -14,6 +14,12 @@ tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-hmth-test
     pullPolicy: IfNotPresent
+
+pprof:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof
+    pullPolicy: IfNotPresent
+
 cray-etcd-base:
   nameOverride: "cray-power-control"
   fullnameOverride: "cray-power-control"

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.6.0
-  testVersion: 2.6.0
+  appVersion: 2.7.0
+  testVersion: 2.7.0
 
 tests:
   image:

--- a/charts/v2.1/cray-power-control/values.yaml
+++ b/charts/v2.1/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.7.0
-  testVersion: 2.7.0
+  appVersion: 2.8.0
+  testVersion: 2.8.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -59,7 +59,7 @@ chartVersionToApplicationVersion:
   "2.1.8": "2.4.0"
   "2.1.9": "2.5.0"
   "2.1.10": "2.6.0"
-  "2.1.11": "2.7.0"
+  "2.1.12": "2.8.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -59,6 +59,7 @@ chartVersionToApplicationVersion:
   "2.1.8": "2.4.0"
   "2.1.9": "2.5.0"
   "2.1.10": "2.6.0"
+  "2.1.11": "2.7.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

Adopted app version 2.8.0 for CSM 1.6.1 (helm chart 2.1.12)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable