### PR TITLE
CASMHMS-5678: Update image and module dependencies

### DIFF
--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - 2025-01-28
+## [2.2.0] - 2025-01-17
 
 ### Security
 

--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -1,0 +1,12 @@
+# Changelog for v2.2
+
+All notable changes to this project for v2.2.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.2.0] - 2025-01-28
+
+### Security
+
+- Update image and module dependencies

--- a/charts/v2.2/cray-power-control/Chart.yaml
+++ b/charts/v2.2/cray-power-control/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: "cray-power-control"
+version: 2.2.0
+description: "Kubernetes resources for cray-power-control"
+home: "https://github.com/Cray-HPE/hms-power-control-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-power-control"
+dependencies:
+  - name: cray-service
+    version: "~11.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.2"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: 2.9.0  # update pprof image version below as well
+annotations:
+  artifacthub.io/images: |-
+    - name: cray-power-control-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.9.0
+  artifacthub.io/license: "MIT"

--- a/charts/v2.2/cray-power-control/templates/configmaps.yaml
+++ b/charts/v2.2/cray-power-control/templates/configmaps.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-power-control-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"

--- a/charts/v2.2/cray-power-control/templates/tests/test-functional.yaml
+++ b/charts/v2.2/cray-power-control/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v2.2/cray-power-control/templates/tests/test-smoke.yaml
+++ b/charts/v2.2/cray-power-control/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-power-control"]

--- a/charts/v2.2/cray-power-control/values.yaml
+++ b/charts/v2.2/cray-power-control/values.yaml
@@ -1,0 +1,166 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+global:
+  appVersion: 2.9.0
+  testVersion: 2.9.0
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-power-control-hmth-test
+    pullPolicy: IfNotPresent
+cray-etcd-base:
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-power-control-bitnami-etcd"
+    nameOverride: "cray-power-control-bitnami-etcd"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-power-control-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
+    extraEnvVars:
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "4200"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "21000"
+      - name: ETCD_MAX_SNAPSHOTS
+        value: "5"
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "10737418240"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "10000"
+      - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+        value: "24"
+      - name: ETCD_DISABLE_PRESTOP
+        value: "yes"
+    extraVolumes:
+      - configMap:
+          defaultMode: 420
+          name: cray-power-control-bitnami-etcd-config
+        name: etcd-config
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-power-control"
+  fullnameOverride: "cray-power-control"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-power-control
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdWaitContainer: true
+  containers:
+    cray-power-control:
+      name: "cray-power-control"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/stable/cray-power-control"
+      resources:
+        limits:
+          cpu: "4"
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 256Mi
+      ports:
+        - name: http
+          containerPort: 28007
+      env:
+        - name: LOG_LEVEL
+          value: "INFO"
+        - name: SMS_SERVER
+          value: "http://cray-smd"
+        - name: VAULT_ENABLED
+          value: "true"
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: TRS_IMPLEMENTATION
+          value: "LOCAL"
+        - name: SERVICE_RESERVATION_VERBOSITY
+          value: "ERROR"
+        - name: HSMLOCK_ENABLED
+          value: "true"
+        - name: STORAGE
+          value: "ETCD"
+        - name: PCS_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: cray-power-control-cacert-info
+              key: CA_URI
+        - name: MAX_NUM_COMPLETED
+          value: "20000"
+        - name: EXPIRE_TIME_MINS
+          value: "1440"
+        - name: PCS_BASE_TRS_TASK_TIMEOUT
+          value: "40"
+        - name: PCS_STATUS_TIMEOUT
+          value: "30"
+        - name: PCS_STATUS_HTTP_RETRIES
+          value: "3"
+        - name: PCS_MAX_IDLE_CONNS
+          value: "4000"
+        - name: PCS_MAX_IDLE_CONNS_PER_HOST
+          value: "4"
+        - name: ETCD_DISABLE_SIZE_CHECKS
+          value: "false"
+        - name: ETCD_PAGE_SIZE
+          value: "5000"
+        - name: ETCD_MAX_OBJECT_SIZE
+          value: "1570000"
+        - name: MAX_TRANSITION_MESSAGE_LENGTH
+          value: "130"
+      livenessProbe:
+        httpGet:
+          port: 28007
+          path: /v1/liveness
+        initialDelaySeconds: 15
+        periodSeconds: 5
+        timeoutSeconds: 3
+      readinessProbe:
+        httpGet:
+          port: 28007
+          path: /v1/readiness
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 25
+      volumeMounts:
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+  ingress:
+    enabled: true
+    uri: "/v1/"
+    prefix: "/apis/power-control/v1/"

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -5,7 +5,9 @@ chartVersionToCSMVersion:
   #   Chart Version: 0.0.1 <= x.y.z < 1.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
   #   Chart Version: 1.0.0 <= x.y.z < 1.1.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
   #   Chart Version: 1.1.0 <= x.y.z < 2.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
-  #   Chart Version: 2.1.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #   Chart Version: 2.1.0 <= x.y.z < 2.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  #   Chart Version: 2.1.0 <= x.y.z < 2.2.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
+  #   Chart Version: 2.2.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
   #
   # Chart version: CSM version
   ">=0.0.1": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
@@ -15,6 +17,7 @@ chartVersionToCSMVersion:
   ">=1.1.0": "~1.5.0"
   ">=2.0.0": "~1.5.0"
   ">=2.1.0": "~1.6.0"
+  ">=2.2.0": "~1.7.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -62,6 +65,7 @@ chartVersionToApplicationVersion:
   "2.1.10": "2.6.0"
   "2.1.11": "2.7.0"
   "2.1.12": "2.8.0"
+  "2.2.0": "2.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -5,7 +5,6 @@ chartVersionToCSMVersion:
   #   Chart Version: 0.0.1 <= x.y.z < 1.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
   #   Chart Version: 1.0.0 <= x.y.z < 1.1.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
   #   Chart Version: 1.1.0 <= x.y.z < 2.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
-  #   Chart Version: 2.1.0 <= x.y.z < 2.1.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
   #   Chart Version: 2.1.0 <= x.y.z < 2.2.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
   #   Chart Version: 2.2.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
   #


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Fixed a bunch of pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

Updating the hms-base module included code changes required to reference code that was moved from hms-base to the hms-xname module.

The tavern tests were updated to look for a returned 404 http code rather than a 405 code due to the gorilla/mux change https://github.com/gorilla/mux/pull/712 that came with updating the gorilla module.

Updates to hms-certs, hms-compcredentials, and hms-securestorage were not included.  A new Jira will be created to handle them seperately.  This is because updating these modules will require functional changes surrounding vault use due to the changes associated with CASMHMS-5445.

Adopted app version 2.9.0 for CSM 1.7.0 (helm chart 2.2.0)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Ran PCS smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable