### PR TITLE
CASMHMS-6482: Update modules to pull in fixes to resource issues in HMS modules

### DIFF
--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,6 +5,18 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2025-04-21
+
+### Update
+
+- Updated image and module dependencies to latest versions
+- Replaced a fair amount of redundant code with reference to new code built
+  into the new hms-base module
+- Update version of Go to v1.24
+- Made several code changes due to upgrade to latest version of Go
+- Fixed jq parsing issue when running local Snyk scans
+- Internal tracking ticket: CASMHMS-6482
+
 ## [2.2.1] - 2025-03-14
 
 ### Security

--- a/charts/v2.2/cray-power-control/Chart.yaml
+++ b/charts/v2.2/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.2.1
+version: 2.2.2
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.10.0  # update pprof image version below as well
+appVersion: 2.11.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.10.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.11.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.2/cray-power-control/values.yaml
+++ b/charts/v2.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.10.0
-  testVersion: 2.10.0
+  appVersion: 2.11.0
+  testVersion: 2.11.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -66,6 +66,7 @@ chartVersionToApplicationVersion:
   "2.1.12": "2.8.0"
   "2.2.0": "2.9.0"
   "2.2.1": "2.10.0"
+  "2.2.2": "2.11.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, hms-hmetcd, and hms-trs-app-api modules.

Replaced a fair amount of redundant code with reference to new code built into the new hms-base module.

Additionally upgraded Go from v1.23 to v1.24.  There were a few code changes that were required to support differences in these two version of Go.

Fixed a jq parsing issue when running local Snyk scans.

Adopted app version 2.11.0 for CSM 1.7.0 (helm chart 2.2.2).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of PCS.  Watched log files to ensure nothing obvious was wrong.  Ran the standard PCS smoke and functional tests which all passed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable