### PR TITLE
CASMHMS-6499: Added 'curl' command to container image

### DIFF
--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.3] - 2025-05-01
+## [2.2.3] - 2025-04-30
 
 ### Update
 

--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2025-05-01
+
+### Update
+
+- Added 'curl' command to container image
+- Internal tracking ticket: CASMHMS-6499
+
 ## [2.2.2] - 2025-04-21
 
 ### Update

--- a/charts/v2.2/cray-power-control/Chart.yaml
+++ b/charts/v2.2/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.2.2
+version: 2.2.3
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.11.0  # update pprof image version below as well
+appVersion: 2.12.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.11.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.12.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.2/cray-power-control/values.yaml
+++ b/charts/v2.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.11.0
-  testVersion: 2.11.0
+  appVersion: 2.12.0
+  testVersion: 2.12.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -67,6 +67,7 @@ chartVersionToApplicationVersion:
   "2.2.0": "2.9.0"
   "2.2.1": "2.10.0"
   "2.2.2": "2.11.0"
+  "2.2.3": "2.12.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Added 'curl' command to container image

Adopted app version 2.12.0 for CSM 1.7.0 (helm chart 2.2.3).

## Issues and Related PRs

* Resolves [CASMHMS-6499](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6499)

## Testing

Tested on:

  * Local development environment

Test description:

Loaded image into Docker Desktop on laptop and verified 'curl' command was present.  No further testing necessary.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable