### PR TITLE
CASMHMS-6512: Bump cray-etcd-base and cray-service to latest versions

### DIFF
--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.4] - 2025-05-13
+
+### Updated
+
+- Updated cray-etcd-base and cray-service dependencies to the latest versions
+- Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+
 ## [2.2.3] - 2025-04-30
 
 ### Update

--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,12 +5,13 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.4] - 2025-05-13
+## [2.2.4] - 2025-05-14
 
 ### Updated
 
 - Updated cray-etcd-base and cray-service dependencies to the latest versions
 - Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+- Internal tracking ticket: CASMHMS-6512
 
 ## [2.2.3] - 2025-04-30
 

--- a/charts/v2.2/cray-power-control/Chart.yaml
+++ b/charts/v2.2/cray-power-control/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.2.3
+version: 2.2.4
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-power-control"
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-etcd-base
-    version: "~1.2"
+    version: "~1.3"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/charts/v2.2/cray-power-control/values.yaml
+++ b/charts/v2.2/cray-power-control/values.yaml
@@ -35,7 +35,7 @@ cray-etcd-base:
       - name: ETCD_MAX_SNAPSHOTS
         value: "5"
       - name: ETCD_QUOTA_BACKEND_BYTES
-        value: "10737418240"
+        value: "2147483648"
       - name: ETCD_SNAPSHOT_COUNT
         value: "10000"
       - name: ETCD_SNAPSHOT_HISTORY_LIMIT

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -68,6 +68,7 @@ chartVersionToApplicationVersion:
   "2.2.1": "2.10.0"
   "2.2.2": "2.11.0"
   "2.2.3": "2.12.0"
+  "2.2.4": "2.12.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Updated cray-etcd-base and cray-service dependencies to the latest versions

Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB

New helm chart version is 2.2.4 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
- Ran HMS CT tests
- Ran etcd health checks to ensure things were healthy from the start:
  - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status`
  - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_database_health`
- Rebuilt the etcd cluster with:
   - `/opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-power-control`
 - Reran etcd health checks to ensure things were still healthy after the rebuild:
   - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status`
   - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_database_health`
- Re-ran HMS CT tests to verify all tests still pass after the rebuild
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable