### PR TITLE
CASMHMS-6302: Fix missing supported power transitions on Gigabyte BMCs

### DIFF
--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.5] - 2025-06-13
+
+- Fixed bug where missing supported power transitions were not getting
+  resync'd with SMD
+- Updated image and module dependencies to latest versions
+- Internal tracking ticket: CASMHMS-6302
+
 ## [2.2.4] - 2025-05-14
 
 ### Updated

--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,10 +5,10 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.5] - 2025-06-13
+## [2.2.5] - 2025-06-12
 
 - Fixed bug where missing supported power transitions were not getting
-  resync'd with SMD
+  resync'd with PCS for Gigabyte BMCs
 - Updated image and module dependencies to latest versions
 - Internal tracking ticket: CASMHMS-6302
 

--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.5] - 2025-06-12
+## [2.2.5] - 2025-06-13
 
 - Fixed bug where missing supported power transitions were not getting
   resync'd with PCS for Gigabyte BMCs

--- a/charts/v2.2/cray-power-control/Chart.yaml
+++ b/charts/v2.2/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.2.4
+version: 2.2.5
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.12.0  # update pprof image version below as well
+appVersion: 2.13.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.12.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.13.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.2/cray-power-control/values.yaml
+++ b/charts/v2.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.12.0
-  testVersion: 2.12.0
+  appVersion: 2.13.0
+  testVersion: 2.13.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -69,6 +69,7 @@ chartVersionToApplicationVersion:
   "2.2.2": "2.11.0"
   "2.2.3": "2.12.0"
   "2.2.4": "2.12.0"
+  "2.2.5": "2.13.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

#### Background and Context

The genesis of the problem being fixed stems from critical data intermittantly going missing from redfish on Gigabyte BMCs.  This is a known problem, and we even have docs-csm documentation covering it:

- [Gigabyte_BMC_Missing_Redfish_Data.md](https://github.com/Cray-HPE/docs-csm/blob/release/1.7/troubleshooting/known_issues/Gigabyte_BMC_Missing_Redfish_Data.md)

The missing data in this case was the `AllowableValues` array in the following redfish structure:

```bash
> curl -sk -u root:${PASSWD} https://x3000c0s28b0/redfish/v1/Managers/Self/ResetActionInfo | jq .Parameters[]
{
  "AllowableValues": [
    "ForceRestart"
  ],
  "DataType": "String",
  "Name": "ResetType",
  "Required": true
}
```

When `discover` is run against a BMC missing this data, SMD will fail to populate the `ResetType@Redfish.AllowableValues` array in the following `componentEndpoint` structure:

```bash
> cray hsm inventory componentEndpoints describe --format json x3000c0s28b0 | jq .RedfishManagerInfo.Actions
{
  "#Manager.Reset": {
    "ResetType@Redfish.AllowableValues": [
      "ForceRestart"
    ],
    "@Redfish.ActionInfo": "/redfish/v1/Managers/Self/ResetActionInfo",
    "target": "/redfish/v1/Managers/Self/Actions/Manager.Reset"
  },
  "Oem": {}
}
```

When PCS retrieves a new `componentEndpoint` from SMD that is missing this data, it will fail to populate the `supportedPowerTransitions` array in the following status structure:

```bash
> cray power status describe x3000c0s28b0 --format json | jq
{
  "status": [
    {
      "xname": "x3000c0s28b0",
      "powerState": "on",
      "managementState": "available",
      "error": "",
      "supportedPowerTransitions": [
        "Soft-Restart"
      ],
      "lastUpdated": "2025-06-11T20:37:01.581816169Z"
    }
  ]
}
```

#### Problem Definition

If `supportedPowerTransitions` is missing for any component, PCS cannot create power transitions for it.

Additionally, if the redfish data later becomes present and discover is then run against it, SMD will correctly populate the `supportedPowerTransitions` array.  However, PCS will not synchronize this change with the `supportedPowerTransitions` field it maintains for the component in etcd.  It does update its in-memory copy correctly, but does not push the in-memory change into etcd because it only does so if a component's power or management state changes.  PCS always retrieves the `supportedPowerTransitions` array from etcd when returning power status to the user and when attempting to create new power transitions.  It does not reference the in-memory copy (and can't because only one replica maintains an in-memory copy).

#### Problem Solution

The only place to detect and correct the issue for the in-memory copy is in `updateComponentMap()`.

The second step is updating peristent memory in etcd, which is done in the `updateHWState()` routine.  But, as mentioned above, if power or management states do not change it will not push an update to etcd. Neither of these states ever change for node BMCs.

After `updateComponentMap()` returns to the `monitorHW()` goroutine, `getHWStatesFromHW()` is immediately called and from there `updateHWState()` is called for each component.

I first attempted to modify `updateHWState()` to detect changes to the in-memory version of the `supportedPowerTransitions` array and then force an etcd update even if the power and management states didn't change.  However, it quickly became obvious that this wouldn't be possible without more significant changes that might include changing the function signature and/or modifying associated data structures to force an update.

To keep the fix simple and incur less risk, I opted to have `updateComponentMap()` directly call `updateHWState()` for any node BMC that it detects this issue on.  To force an etcd write, `updateComponentMap()` requests that `updateHWState()` change the power and management states to "undefined", which will also cause an update to the `supportedPowerTransitions` array in etcd.  This is fine, because we're guaranteed that `updateHWState()` will be called again shortly after by the `monitorHW()` -> `getHWStatesFromHW()` -> `updateHWState()` path, with the corrected power and management states.  PCS already does something similar when it has communication issues with BMCs (it sets their nodes to have "undefined" states until the BMC resumes communication).

The image and module dependencies were also updated as part of this PR.

Adopted app version 2.13.0 for CSM 1.7.0 (helm chart 2.2.5).

### Issues and Related PRs

* Resolves [CASMHMS-6302](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6302)

### Testing

Tested on:

* `gamora`

Test description:

I tested on gamora since it had about a dozen Gigabyte BMC's with missing `AllowableValues` in SMD and `supportedPowerTransitions` in PCS.

The `AllowableValues` data was now present in all of the BMC's redfish, so I ran discover against a few of them.  After doing this, the `AllowableValues` data then became present in SMD.  However, `supportedPowerTransitions` was still missing in PCS.

I then put the PCS fix in place and repeated the `discover` on a few other BMCs.  In addition to the data correctly populating in SMD, it now also correctly populated in PCS and PCS's etcd backing store.

I had debug logging in place to ensure all the correct paths were being taken.

Finally, I ran CT tests and observed all tests passing.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable