### PR TITLE
CASMHMS-6599: Update PCS dependencies

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -2,5 +2,5 @@ name: Kubernetes API Checker
 on: [push, pull_request, workflow_dispatch]
 jobs:
   k8s_api_checker:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v4
     secrets: inherit

--- a/changelog/v2.2.md
+++ b/changelog/v2.2.md
@@ -5,6 +5,16 @@ All notable changes to this project for v2.2.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] - 2025-09-23
+
+### Security
+
+- Updated Alpine base image to pick up security fixes
+- Updated HMS image version dependencies
+- Updated HMS Go module dependencies
+- Updated k8s_api_checker.yaml from v2 to v4
+- Internal tracking ticket: CASMHMS-6599
+
 ## [2.2.5] - 2025-06-13
 
 - Fixed bug where missing supported power transitions were not getting

--- a/charts/v2.2/cray-power-control/Chart.yaml
+++ b/charts/v2.2/cray-power-control/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-power-control"
-version: 2.2.5
+version: 2.2.6
 description: "Kubernetes resources for cray-power-control"
 home: "https://github.com/Cray-HPE/hms-power-control-charts"
 sources:
@@ -15,9 +15,9 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 2.13.0  # update pprof image version below as well
+appVersion: 2.14.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-power-control-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.13.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-power-control-pprof:2.14.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.2/cray-power-control/values.yaml
+++ b/charts/v2.2/cray-power-control/values.yaml
@@ -7,8 +7,8 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 global:
-  appVersion: 2.13.0
-  testVersion: 2.13.0
+  appVersion: 2.14.0
+  testVersion: 2.14.0
 
 tests:
   image:

--- a/cray-hms-power-control.compatibility.yaml
+++ b/cray-hms-power-control.compatibility.yaml
@@ -70,6 +70,7 @@ chartVersionToApplicationVersion:
   "2.2.3": "2.12.0"
   "2.2.4": "2.12.0"
   "2.2.5": "2.13.0"
+  "2.2.6": "2.14.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated all of the HMS image and Go module dependencies.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 because we were having build issues.

Adopted app version 2.14.0 for CSM 1.7.1 (helm chart 2.2.6)

### Issues and Related PRs

* Resolves [CASMHMS-6599](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6599)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable